### PR TITLE
Add Windows wheel build support using vcpkg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
         # explicitly here.
         os:
         - ubuntu-latest
+        - windows-latest
         cibw_skip:
         - pp* *-musllinux_* *i686
         arch:
@@ -50,6 +51,7 @@ jobs:
       env:
         CIBW_SKIP: ${{ matrix.cibw_skip }}
         CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+        CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
         CIBW_ENVIRONMENT: PYTHONUTF8=1
         PYTHONUTF8: '1'
     - name: Show built files

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ _skbuild
 pip-wheel-metadata/
 
 wheelhouse
+vcpkg/

--- a/dev/setup_windows_opencv.ps1
+++ b/dev/setup_windows_opencv.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = "Stop"
+
+$Triplet = "x64-windows"
+
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$vcpkgRoot = Join-Path $projectRoot 'vcpkg'
+
+Write-Host "Project root: $projectRoot"
+Write-Host "Using vcpkg root: $vcpkgRoot"
+
+if (-not (Test-Path $vcpkgRoot)) {
+    Write-Host "Cloning vcpkg..."
+    git clone --depth 1 https://github.com/microsoft/vcpkg $vcpkgRoot
+} else {
+    Write-Host "Reusing existing vcpkg checkout"
+}
+
+Push-Location $vcpkgRoot
+try {
+    $bootstrapPath = Join-Path $vcpkgRoot 'bootstrap-vcpkg.bat'
+    $vcpkgExe = Join-Path $vcpkgRoot 'vcpkg.exe'
+    if (-not (Test-Path $vcpkgExe)) {
+        Write-Host "Bootstrapping vcpkg..."
+        & $bootstrapPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "bootstrap-vcpkg failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    $args = @('install', "opencv[core]:$Triplet", '--recurse')
+    Write-Host "Installing opencv via vcpkg..."
+    & $vcpkgExe @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "vcpkg install failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Pop-Location
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,16 +58,17 @@ yum -y install epel-release
 yum -y install opencv-devel
 """
 
+[tool.cibuildwheel.windows.environment]
+VCPKG_DEFAULT_TRIPLET = "x64-windows"
+VCPKG_TARGET_TRIPLET  = "x64-windows"
+VCPKG_ROOT            = "{project}\\vcpkg"
+CMAKE_TOOLCHAIN_FILE  = "{project}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+OpenCV_DIR            = "{project}\\vcpkg\\installed\\x64-windows\\share\\opencv"
+OpenCV_ROOT           = "{project}\\vcpkg\\installed\\x64-windows"
+PATH                  = "{env:PATH};{project}\\vcpkg\\installed\\x64-windows\\bin"
+
+
 [tool.cibuildwheel.windows]
-environment = {
-    VCPKG_DEFAULT_TRIPLET = "x64-windows",
-    VCPKG_TARGET_TRIPLET = "x64-windows",
-    VCPKG_ROOT = "{project}\\vcpkg",
-    CMAKE_TOOLCHAIN_FILE = "{project}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake",
-    OpenCV_DIR = "{project}\\vcpkg\\installed\\x64-windows\\share\\opencv",
-    OpenCV_ROOT = "{project}\\vcpkg\\installed\\x64-windows",
-    PATH = "{env:PATH};{project}\\vcpkg\\installed\\x64-windows\\bin",
-}
 before-build = """
 python -m pip install --upgrade pip delvewheel
 powershell -ExecutionPolicy Bypass -File .\\dev\\setup_windows_opencv.ps1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,21 @@ yum -y install epel-release
 yum -y install opencv-devel
 """
 
-#[tool.cibuildwheel.windows]
-#before-all = "choco install lz4 -y"
+[tool.cibuildwheel.windows]
+environment = {
+    VCPKG_DEFAULT_TRIPLET = "x64-windows",
+    VCPKG_TARGET_TRIPLET = "x64-windows",
+    VCPKG_ROOT = "{project}\\vcpkg",
+    CMAKE_TOOLCHAIN_FILE = "{project}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake",
+    OpenCV_DIR = "{project}\\vcpkg\\installed\\x64-windows\\share\\opencv",
+    OpenCV_ROOT = "{project}\\vcpkg\\installed\\x64-windows",
+    PATH = "{env:PATH};{project}\\vcpkg\\installed\\x64-windows\\bin",
+}
+before-build = """
+python -m pip install --upgrade pip delvewheel
+powershell -ExecutionPolicy Bypass -File .\\dev\\setup_windows_opencv.ps1
+"""
+repair-wheel-command = "delvewheel repair --add-path {project}\\vcpkg\\installed\\x64-windows\\bin -w {dest_dir} {wheel}"
 
 #[tool.cibuildwheel.macos]
 #before-all = "brew install lz4"


### PR DESCRIPTION
## Summary
- extend the cibuildwheel workflow to build wheels on windows runners
- add a powershell helper that provisions OpenCV via vcpkg and use delvewheel for repairing wheels
- ensure the temporary vcpkg checkout is ignored by git

## Testing
- not run (covered by CI)

------
https://chatgpt.com/codex/tasks/task_b_68dd4ed4a354832d85d107de66041bae