### PR TITLE
Add Windows wheel build support in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
         # explicitly here.
         os:
         - ubuntu-latest
+        - windows-latest
         cibw_skip:
         - pp* *-musllinux_* *i686
         arch:
@@ -53,8 +54,16 @@ jobs:
         CIBW_ENVIRONMENT: PYTHONUTF8=1
         PYTHONUTF8: '1'
     - name: Show built files
-      shell: bash
-      run: ls -la wheelhouse
+      shell: python
+      run: |
+        import pathlib
+        wheelhouse = pathlib.Path("wheelhouse")
+        if not wheelhouse.exists():
+            raise SystemExit("wheelhouse directory was not created")
+        print("wheelhouse contents:")
+        for path in sorted(wheelhouse.glob("*")):
+            size = path.stat().st_size
+            print(f"  {path.name} - {size} bytes")
     - name: Set up Python 3.13 to combine coverage
       uses: actions/setup-python@v5.6.0
       if: runner.os == 'Linux'
@@ -142,6 +151,10 @@ jobs:
         - python-version: 3.14.0-rc.1
           install-extras: tests,optional,headless
           os: ubuntu-latest
+          arch: auto
+        - python-version: '3.11'
+          install-extras: tests,optional,headless
+          os: windows-latest
           arch: auto
     steps:
     - name: Checkout source

--- a/dev/windows-install-opencv.bat
+++ b/dev/windows-install-opencv.bat
@@ -1,0 +1,30 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "VCPKG_ROOT=C:\vcpkg"
+set "VCPKG_REPO=https://github.com/microsoft/vcpkg.git"
+set "VCPKG_TRIPLET=x64-windows"
+
+if not exist "%VCPKG_ROOT%" (
+    echo [vtool_ibeis_ext] Cloning vcpkg into %VCPKG_ROOT%
+    git clone --depth 1 "%VCPKG_REPO%" "%VCPKG_ROOT%"
+    if errorlevel 1 (
+        echo Failed to clone vcpkg repository.
+        exit /b 1
+    )
+    call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" -disableMetrics
+    if errorlevel 1 (
+        echo Failed to bootstrap vcpkg.
+        exit /b 1
+    )
+) else (
+    echo [vtool_ibeis_ext] Using existing vcpkg checkout at %VCPKG_ROOT%
+)
+
+"%VCPKG_ROOT%\vcpkg.exe" install opencv[core]:%VCPKG_TRIPLET% --recurse --clean-after-build
+if errorlevel 1 (
+    echo Failed to install OpenCV via vcpkg.
+    exit /b 1
+)
+
+endlocal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [ "setuptools>=41.0.1", "scikit-build>=0.11.1", "numpy", "ninja>=1.10
 
 build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
 build-frontend = "build"
-skip = "pp* *-musllinux_* *i686"
+skip = "pp* *-musllinux_* *i686 *-win32"
 build-verbosity = 1
 test-extras = [ "tests-strict", "runtime-strict",]
 test-command = "python {project}/run_tests.py"
@@ -67,7 +67,8 @@ repair-wheel-command = "python -m delvewheel repair --add-path C:\\vcpkg\\instal
 VCPKG_ROOT = "C:\\vcpkg"
 VCPKG_DEFAULT_TRIPLET = "x64-windows"
 CMAKE_TOOLCHAIN_FILE = "C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
-OpenCV_DIR = "C:\\vcpkg\\installed\\x64-windows\\share\\opencv4"
+CMAKE_ARGS = "-DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+OpenCV_DIR = "C:\\vcpkg\\installed\\x64-windows\\share\\opencv"
 OpenCV_ROOT = "C:\\vcpkg\\installed\\x64-windows"
 PATH = "{env:PATH};C:\\vcpkg\\installed\\x64-windows\\bin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,18 @@ yum -y install epel-release
 yum -y install opencv-devel
 """
 
-#[tool.cibuildwheel.windows]
-#before-all = "choco install lz4 -y"
+[tool.cibuildwheel.windows]
+before-all = "\"{project}\\dev\\windows-install-opencv.bat\""
+before-build = "python -m pip install delvewheel"
+repair-wheel-command = "python -m delvewheel repair --add-path C:\\vcpkg\\installed\\x64-windows\\bin -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.windows.environment]
+VCPKG_ROOT = "C:\\vcpkg"
+VCPKG_DEFAULT_TRIPLET = "x64-windows"
+CMAKE_TOOLCHAIN_FILE = "C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+OpenCV_DIR = "C:\\vcpkg\\installed\\x64-windows\\share\\opencv4"
+OpenCV_ROOT = "C:\\vcpkg\\installed\\x64-windows"
+PATH = "{env:PATH};C:\\vcpkg\\installed\\x64-windows\\bin"
 
 #[tool.cibuildwheel.macos]
 #before-all = "brew install lz4"


### PR DESCRIPTION
## Summary
- add a Windows runner to the wheel build and test jobs
- install OpenCV through vcpkg during cibuildwheel runs and repair wheels with delvewheel
- add a helper script that bootstraps vcpkg with the required OpenCV components

## Testing
- not run (covered by CI)


------
https://chatgpt.com/codex/tasks/task_b_68dd4ed4a354832d85d107de66041bae